### PR TITLE
Feature/35 pester tests for block classes

### DIFF
--- a/.vscode/profile.ps1
+++ b/.vscode/profile.ps1
@@ -1,0 +1,5 @@
+Set-Location "$env:USERPROFILE\Documents\PowerShell\Modules.DEV\TSNotion"
+./build.ps1 -tasks minibuild
+$version = dotnet-gitversion /showvariable MajorMinorPatch /nocache
+$ModuleFile = ".\output\module\Notion\$version\Notion.psd1"
+Import-Module $ModuleFile

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,12 +44,26 @@
     "vsicons.associations.files": [
         {
             "icon": "pester",
-            "extensions": ["Tests.ps1", "tests.ps1"],
+            "extensions": [
+                "Tests.ps1",
+                "tests.ps1"
+            ],
             "format": "svg"
         }
     ],
     "liveshare.languages.allowGuestCommandControl": true,
     "liveshare.allowGuestDebugControl": true,
     "workbench.iconTheme": "vscode-icons",
-    "terminal.integrated.bracketedPasteMode": false
+    "terminal.integrated.bracketedPasteMode": false,
+    "terminal.integrated.profiles.windows": {
+        "Notion pwsh": {
+            "source": "PowerShell",
+            "args": [
+                "-NoExit",
+                "-Command",
+                "& './.vscode/profile.ps1'"
+            ]
+        }
+    },
+    "terminal.integrated.defaultProfile.windows": "Notion pwsh"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
 ### Added
 
-- `.vscode/settings.json`: added `terminal.integrated.bracketedPasteMode` setting
+- `.vscode/settings.json`: added `terminal.integrated.bracketedPasteMode`, disabled minimap, and configured custom terminal profile
+- `.vscode/profile.ps1`: PowerShell profile to auto-import the module during development
+- `.vscode/vsicons-custom-icons/`: added custom icon support for Pester files
+- `.build/Copy-WikiContent.ps1`: script to copy wiki content from source to destination, flattening structure
+- `.build/New-WikiSidebarFromPs1.ps1`: script to generate `_Sidebar.md` from PowerShell and Markdown files
+- `.build/README.md`: documentation for adding custom build tasks and workflows
 - `build.yaml`: added `minibuild` task with steps for `Clean`, `Build_Module_ModuleBuilder`, and `Build_NestedModules_ModuleBuilder`
 - `source/Classes/03_File/01_notion_file.ps1`:  
   - Added static `Create` method to instantiate child objects based on file type
@@ -42,17 +46,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `ConvertFromObject` method to handle strings and emoji objects
 - `tests/Integration/Block/testpage.tests.ps1`:  
   - Improved test logic for unsupported block types with specific error message checks
+- `source/Public/Block/New-NotionBlock.ps1`: generic factory function to create Notion blocks
+- `source/Public/Block/Cmds/*`: added many new `New-Notion*Block.ps1` cmdlets for block creation (e.g., `Bookmark`, `Callout`, `ChildPage`, `Code`, etc.)
+- `docs/Enums/`: added Markdown documentation for all enums used in the module
+- `source/WikiSource/`: added wiki source files including setup guide, FAQ, and integration images
+- `tests/Unit/Classes/Block/`: added unit tests for many block classes (e.g., `Bookmark`, `Breadcrumb`, `Callout`, `Code`, `Image`, `Video`, etc.)
 
 ### Changed
 
 - `RequiredModules.psd1`: switched to Pester Version 6
+- `.vscode/analyzersettings.psd1`: relaxed some analyzer rules (e.g., allow `Write-Host`)
+- `.github/ISSUE_TEMPLATE/`: updated templates to reflect support for commands, classes, and enums
+- `README.md`: added badges, logo, and improved getting started section
+- `build.ps1`: added tasks `Generate_Wiki_Sidebar_From_Ps1` and `Copy_Wiki_Content_Custom`
 - Refactored multiple constructors across block classes to support more flexible input types and use `ConvertFromObjects` for consistency
+- `source/Classes/Emoji/01_emoji.ps1`: improved emoji conversion logic
+- `source/Enum/*`: added missing enum values and documentation links
 
 ### Fixed
 
-- `source/Enum/01_notion_color.ps1`: added `default_backround` as a color (missing in documentation but available in API)
-- `source/Classes/Block/32_Toggle.ps1`: fixed class `notion_toggle_block`
-- `source/Classes/Block/33_Video.ps1`: fixed constructors to use `Create` method and correct file instantiation
+- `source/Enum/01_notion_color.ps1`: added `default_background` as a color (missing in documentation but available in API)
+- `source/Classes/Block/32_Toggle.ps1`: fixed class name and constructor
+- `source/Classes/Block/33_Video.ps1`: fixed constructors and file instantiation logic
 - `source/Classes/Block/05_Bookmark.ps1`:  
   - Fixed constructors  
   - `bookmark_structure`: fixed constructor with two parameters to fully support `rich_text`
@@ -62,7 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed constructors and emoji handling
 - `source/Classes/Emoji/01_emoji.ps1`:  
   - Fixed `ConvertFromObject` to handle strings and emoji objects
-
+- `tests/Integration/Block/testpage.tests.ps1`: improved error handling and validation for unsupported block types
+- `tests/Integration/PageProperties/testpage.tests.ps1`: added validation for page property types
 
 ## [0.3.0] - 2025-05-18
 

--- a/source/Classes/03_File/01_notion_file.ps1
+++ b/source/Classes/03_File/01_notion_file.ps1
@@ -22,58 +22,18 @@ class notion_file : notion_icon
         $this.name = $name
     }
 
-    #string caption (optional)
-    notion_file([notion_filetype]$type, [string]$name, [string]$caption = "")
-    {
-        $this.type = $type
-        $this.name = $name
-        if ([string]::IsNullOrEmpty($caption) -eq $false)
-        {
-            $this.caption = @([rich_text_text]::new($caption))
-        }
-    }
 
-    notion_file([notion_filetype]$type, [string]$name, [object[]] $caption)
+    notion_file([notion_filetype]$type, [string]$name, $caption)
     {
         Write-Verbose "[notion_file]::new($type, $name, $($caption | ConvertTo-Json))"
         $this.type = $type
         $this.name = $name
-        $this.caption = @()
-        foreach ($item in $caption)
-        {
-            if ($item -is [string])
-            {
-                $this.caption += [rich_text_text]::new($item)
-            }
-            elseif ($item -is [rich_text])
-            {
-                $this.caption += $item
-            }
-            else
-            {
-                $this.caption += [rich_text]::ConvertFromObject($item)
-            }
-        }
+        $this.caption = [rich_text]::ConvertFromObjects($caption)
     }
 
-    static [notion_file] Create([notion_filetype] $type, [string] $name, [object[]] $caption, [string] $url, $expiry_time = $null  )
+    static [notion_file] Create([notion_filetype] $type, [string] $name, $caption, [string] $url, $expiry_time = $null  )
     {
-        $processedCaption = @()
-        foreach ($item in $caption)
-        {
-            if ($item -is [string])
-            {
-                $processedCaption += [rich_text_text]::new($item)
-            }
-            elseif ($item -is [rich_text])
-            {
-                $processedCaption += $item
-            }
-            else
-            {
-                $processedCaption += [rich_text]::ConvertFromObject($item)
-            }
-        }
+        $processedCaption = [rich_text]::ConvertFromObjects($caption)
 
         switch ($type)
         {
@@ -116,7 +76,7 @@ class notion_file : notion_icon
             $fileObject = [notion_external_file]::ConvertFromObject($Value)
         }
         $fileObject.type = $Value.type
-        $fileObject.caption = $Value.caption.ForEach({ [rich_text]::ConvertFromObject($_) })
+        $fileObject.caption = [rich_text]::ConvertFromObjects($Value.caption)
         $fileObject.name = $Value.name
         return $fileObject
     }

--- a/source/Classes/03_File/02_notion_hosted_file.ps1
+++ b/source/Classes/03_File/02_notion_hosted_file.ps1
@@ -22,6 +22,11 @@ class notion_hosted_file_structure
 
     static [notion_hosted_file_structure] ConvertFromObject($Value)
     {
+        if ($Value -is [notion_hosted_file_structure])
+        {
+            Write-Verbose "[notion_hosted_file_structure]::ConvertFromObject($($Value | ConvertTo-Json)) - already a notion_hosted_file_structure"
+            return $Value
+        }
         Write-Verbose "[notion_hosted_file_structure]::ConvertFromObject($($Value | ConvertTo-Json))"
         return [notion_hosted_file_structure]::new($Value.url, $Value.expiry_time)
     }
@@ -35,15 +40,10 @@ class notion_hosted_file : notion_file
     {
     }
 
-    notion_hosted_file([string]$name, [string]$caption="",[string]$url, $expiry_time):base("file", $name, $caption)
-    {
-        Write-Verbose "[notion_hosted_file]::new($name, $caption, $url, $expiry_time)"
-        $this.file = [notion_hosted_file_structure]::new($url, $expiry_time)
-    }
-
-    notion_hosted_file([string]$name, [object[]]$caption, [string]$url, $expiry_time):base("file", $name, $caption)
+    notion_hosted_file([string]$name, $caption, [string]$url, $expiry_time):base("file", $name, $caption)
     {
         Write-Verbose "[notion_hosted_file]::new($name, $($caption | ConvertTo-Json), $url, $expiry_time)"
+        $caption = [rich_text]::ConvertFromObject($caption)
         $this.file = [notion_hosted_file_structure]::new($url, $expiry_time)
     }
 
@@ -53,7 +53,7 @@ class notion_hosted_file : notion_file
         $notion_file_obj = [notion_hosted_file]::new()
         $notion_file_obj.file = [notion_hosted_file_structure]::ConvertFromObject($Value.file)
         $notion_file_obj.type = $Value.type
-        $notion_file_obj.caption = $Value.caption.ForEach({[rich_text]::ConvertFromObject($_)})
+        $notion_file_obj.caption = [rich_text]::ConvertFromObjects($Value.caption)
         $notion_file_obj.name = $Value.name
         return $notion_file_obj
     }

--- a/source/Classes/03_File/03_external_file.ps1
+++ b/source/Classes/03_File/03_external_file.ps1
@@ -23,11 +23,12 @@ class notion_external_file : notion_file
     notion_external_file():base("external")
     {
     }
-    notion_external_file([string]$name, [string]$caption="",[string]$url):base("external", $name, $caption)
+    notion_external_file([string]$name, $url):base("external", $name)
     {
         $this.external = [notion_external_file_structure]::new($url)
     }
-    notion_external_file([string]$name, [rich_text[]]$caption, [string]$url):base("external", $name, $caption)
+
+    notion_external_file([string]$name, $caption, [string]$url):base("external", $name, $caption)
     {
         $this.external = [notion_external_file_structure]::new($url)
     }
@@ -39,7 +40,7 @@ class notion_external_file : notion_file
         $notionFileOb = [notion_external_file]::new()
         $notionFileOb.external = [notion_external_file_structure]::ConvertFromObject($Value.external)
         $notionFileOb.type = $Value.type
-        $notionFileOb.caption = $Value.caption.ForEach({[rich_text]::ConvertFromObject($_)})
+        $notionFileOb.caption = $Value.caption.ForEach({ [rich_text]::ConvertFromObject($_) })
         $notionFileOb.name = $Value.name
         return $notionFileOb
     }

--- a/source/Classes/Block/08_Callout.ps1
+++ b/source/Classes/Block/08_Callout.ps1
@@ -2,7 +2,7 @@ class callout_structure
 {
     [rich_text[]] $rich_text
     # icon: emoji or file
-    [notion_emoji]$icon
+    [notion_emoji] $icon
     [notion_color] $color = "default"
 
     callout_structure()

--- a/source/Classes/Block/22_Numbered_List_Item.ps1
+++ b/source/Classes/Block/22_Numbered_List_Item.ps1
@@ -9,21 +9,21 @@ class numbered_list_item_structure
     {
     }
 
-    numbered_list_item_structure([rich_text[]] $rich_text)
+    numbered_list_item_structure($rich_text)
     {
-        $this.rich_text = $rich_text
+        $this.rich_text = [rich_text]::ConvertFromObjects($rich_text)
     }
-    numbered_list_item_structure([rich_text[]] $rich_text, [notion_color] $color)
+    numbered_list_item_structure($rich_text, [notion_color] $color)
     {
-        $this.rich_text = $rich_text
-        $this.color = $color
+        $this.rich_text = [rich_text]::ConvertFromObjects($rich_text)
+        $this.color = [Enum]::Parse([notion_color], $color)
     }
 
 
     static [numbered_list_item_structure] ConvertFromObject($Value)
     {
         $numbered_list_item_structure = [numbered_list_item_structure]::new()
-        $numbered_list_item_structure.rich_text = $Value.rich_text.ForEach({ [rich_text]::ConvertFromObject($_) })
+        $numbered_list_item_structure.rich_text = [rich_text]::ConvertFromObjects($Value.rich_text)
         $numbered_list_item_structure.color = [Enum]::Parse([notion_color], ($Value.color ?? "default"))
         return $numbered_list_item_structure
     }
@@ -34,11 +34,11 @@ class notion_numbered_list_item_block : notion_block
     [notion_blocktype] $type = "numbered_list_item"
     [numbered_list_item_structure] $numbered_list_item
 
-    notion_numbered_list_item_block() : base("numbered_list_item")
+    notion_numbered_list_item_block()
     {
     }
 
-    notion_numbered_list_item_block([rich_text[]] $rich_text) : base("numbered_list_item")
+    notion_numbered_list_item_block($rich_text)
     {
         $this.numbered_list_item = [numbered_list_item_structure]::new($rich_text)
     }

--- a/source/Classes/Block/23.1_File_block.ps1
+++ b/source/Classes/Block/23.1_File_block.ps1
@@ -1,4 +1,5 @@
-class notion_file_block : notion_block {
+class notion_file_block : notion_block 
+{
     #https://developers.notion.com/reference/block#file
     [notion_blocktype] $type = "file"
     [notion_file]$file
@@ -7,35 +8,35 @@ class notion_file_block : notion_block {
     {
     }
     
-    notion_file_block([string]$name, [string]$caption="",[string]$url, $expiry_time)
+    notion_file_block($name, $caption, $url, $expiry_time)
     {
+        $caption = [rich_text]::ConvertFromObjects($caption)
         $this.file = [notion_hosted_file]::new($name, $caption, $url, $expiry_time)
     }
 
-    notion_file_block([string]$name, [rich_text[]]$caption, [string]$url, $expiry_time)
-    {
-        $this.file = [notion_hosted_file]::new($name, $caption, $url, $expiry_time)
-    }
 
-    notion_file_block([string]$name, [string]$caption="",[string]$url)
+    notion_file_block($name, $caption, [string]$url)
     {
+        $caption = [rich_text]::ConvertFromObjects($caption)
         $this.file = [notion_external_file]::new($name, $caption, $url)
     }
 
-    notion_file_block([string]$name, [rich_text[]]$caption, [string]$url)
-    {
-        $this.file = [notion_external_file]::new($name, $caption, $url)
-    }
 
     #direct object assignment, expected input is either notion_hosted_file or notion_external_file
-    notion_file_block([notion_file]$file)
+    notion_file_block($file)
     {
-        $this.file = $file
+        $this.file = [notion_file]::ConvertFromObject($file)
     }
 
     static [notion_file_block] ConvertFromObject($Value)
     {
         Write-Verbose "[notion_file_block]::ConvertFromObject($($Value | ConvertTo-Json))"
-        return [notion_file]::ConvertFromObject($Value.file)
+        if ($Value -is [notion_file_block])
+        {
+            return $Value
+        }
+        $obj = [notion_file_block]::new()
+        $obj.file = [notion_file]::ConvertFromObject($Value.file)
+        return $obj
     }
 }

--- a/source/Classes/Block/23_Paragraph.ps1
+++ b/source/Classes/Block/23_Paragraph.ps1
@@ -9,20 +9,20 @@ class paragraph_structure
     {
     }
 
-    paragraph_structure([rich_text[]] $rich_text)
+    paragraph_structure($rich_text)
     {
-        $this.rich_text = $rich_text
+        $this.rich_text = [rich_text]::ConvertFromObjects($rich_text)
     }
 
-    [void] addRichText([rich_text] $richtext)
+    [void] addRichText($rich_text)
     {
-        $this.rich_text += $richtext
+        $this.rich_text += [rich_text]::ConvertFromObjects($rich_text)
     }
 
     static [paragraph_structure] ConvertFromObject($Value)
     {
         $Paragraph = [paragraph_structure]::new()
-        $Paragraph.rich_text = $Value.rich_text.ForEach({ [rich_text]::ConvertFromObject($_) })
+        $Paragraph.rich_text = [rich_text]::ConvertFromObjects($Value.rich_text)
         $Paragraph.color = [Enum]::Parse([notion_color], ($Value.color ?? "default"))
         return $Paragraph
     }
@@ -38,12 +38,12 @@ class notion_paragraph_block : notion_block
         $this.paragraph = [Paragraph_structure]::new(@())
     }
 
-    notion_paragraph_block([rich_text] $richtext)
+    notion_paragraph_block($richtext)
     {
-        $this.paragraph = [Paragraph_structure]::new(@($richtext))
+        $this.paragraph = [Paragraph_structure]::new($richtext)
     }
 
-    [void] addRichText([rich_text] $richtext)
+    [void] addRichText($richtext)
     {
         $this.paragraph = [Paragraph_structure]::addRichText($richtext)
     }

--- a/source/Public/Block/Bookmark/New-NotionBookmarkBlock.ps1
+++ b/source/Public/Block/Bookmark/New-NotionBookmarkBlock.ps1
@@ -1,0 +1,58 @@
+
+function New-NotionBookmarkBlock
+{
+    <#
+        .SYNOPSIS
+            Creates a new Notion bookmark block object.
+        
+        .DESCRIPTION
+            The New-NotionBookmarkBlock function instantiates a new notion_bookmark_block object.
+            You can optionally provide a URL and/or a caption for the bookmark block.
+        
+        .PARAMETER Url
+            The URL to associate with the bookmark block.
+        
+        .PARAMETER Caption
+            The caption to display for the bookmark block.
+        
+        .EXAMPLE
+            New-NotionBookmarkBlock -Url "https://example.com" -Caption "Example Site"
+        
+            Creates a new bookmark block with the specified URL and caption.
+        
+        .EXAMPLE
+            New-NotionBookmarkBlock -Url "https://example.com"
+        
+            Creates a new bookmark block with only the specified URL.
+
+        .OUTPUTS
+            [notion_bookmark_block]
+            Returns a new instance of the notion_bookmark_block object.
+        
+        .NOTES
+            
+        #>
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
+    [OutputType([void])]
+    param (
+        [Parameter(ParameterSetName = 'Default', HelpMessage = 'The URL for the bookmark block.')]
+        [string]$Url,
+    
+        [Parameter(ParameterSetName = 'Default', HelpMessage = 'The caption for the bookmark.')]
+        [object]$Caption
+    )
+    
+    if ($PSBoundParameters.ContainsKey('Caption') -and $PSBoundParameters.ContainsKey('Url'))
+    {
+        $obj = [notion_bookmark_block]::new($Caption, $Url)
+    }
+    elseif ($PSBoundParameters.ContainsKey('Url'))
+    {
+        $obj = [notion_bookmark_block]::new($Url)
+    }
+    else
+    {
+        $obj = [notion_bookmark_block]::new()
+    }
+    return $obj
+}

--- a/source/Public/Block/Breadcrumb/New-NotionBreadcrumbBlock.ps1
+++ b/source/Public/Block/Breadcrumb/New-NotionBreadcrumbBlock.ps1
@@ -1,0 +1,23 @@
+function New-NotionBreadcrumbBlock
+{
+    <#
+    .SYNOPSIS
+        Creates a new Notion breadcrumb block object.
+    
+    .DESCRIPTION
+        The New-NotionBreadcrumbBlock function instantiates and returns a new notion_breadcrumb_block object.
+        This is typically used to add a breadcrumb block to a Notion page via automation or scripting.
+    
+    .EXAMPLE
+        New-NotionBreadcrumbBlock
+    
+        Creates a new breadcrumb block object for use with Notion integrations.
+    
+    .OUTPUTS
+        notion_breadcrumb_block object
+    #>
+    [CmdletBinding()]
+    [OutputType([notion_breadcrumb_block])]
+    param( )
+    return [notion_breadcrumb_block]::new()
+}

--- a/source/Public/Block/Cmds/BulletedListItem/New-NotionBulletedListItemBlock.ps1
+++ b/source/Public/Block/Cmds/BulletedListItem/New-NotionBulletedListItemBlock.ps1
@@ -1,0 +1,12 @@
+function New-NotionBulletedListItemBlock
+{
+    [CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/Callout/New-NotionCalloutBlock.ps1
+++ b/source/Public/Block/Cmds/Callout/New-NotionCalloutBlock.ps1
@@ -1,0 +1,54 @@
+function New-NotionCalloutBlock
+{
+    <#
+    .SYNOPSIS
+        Creates a new Notion callout block object.
+
+    .DESCRIPTION
+        This function creates a new instance of the notion_callout_block class.
+        All supported constructors of the class are covered:
+        - No parameters (creates an empty callout)
+        - With rich_text, icon, and color
+
+    .PARAMETER RichText
+        The rich text content for the callout block.
+
+    .PARAMETER Icon
+        The icon (emoji or file) for the callout block.
+
+    .PARAMETER Color
+        The color for the callout block.
+        
+    .EXAMPLE
+    New-NotionCalloutBlock -RichText "Hello" -Icon ":bulb:" -Color "yellow"
+    
+    .EXAMPLE
+    New-NotionCalloutBlock
+    
+    .OUTPUTS
+        notion_callout_block
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
+    param (
+        [Parameter(ParameterSetName = 'Default', HelpMessage = 'Rich text content for the callout block.')]
+        $RichText,
+
+        [Parameter(ParameterSetName = 'Default', HelpMessage = 'Icon (object). Can be an emoji or a file.')]
+        $Icon,
+
+        [Parameter(ParameterSetName = 'Default', HelpMessage = 'Color of the callout block.')]
+        [notion_color] $Color = [notion_color]::Default
+    )
+    $obj = $null
+    if ($PSBoundParameters.ContainsKey('RichText') -and $PSBoundParameters.ContainsKey('Icon') -and $PSBoundParameters.ContainsKey('Color'))
+    {
+        $RichText = [rich_text]::ConvertFromObjects($RichText)
+        $Icon = [notion_emoji]::ConvertFromObject($Icon)
+        $obj = [notion_callout_block]::new($RichText, $Icon, $Color)
+    }
+    else
+    {
+        $obj = [notion_callout_block]::new()
+    }
+    return $obj
+}

--- a/source/Public/Block/Cmds/ChildDatabase/New-NotionChildDatabaseBlock.ps1
+++ b/source/Public/Block/Cmds/ChildDatabase/New-NotionChildDatabaseBlock.ps1
@@ -22,7 +22,7 @@ function New-NotionChildDatabaseBlock
     #>
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
-        [Parameter(ParameterSetName = 'Default')]
+        [Parameter(ParameterSetName = 'Default', HelpMessage = 'Title of the child database.')]
         [string] $Title
     )
 

--- a/source/Public/Block/Cmds/ChildDatabase/New-NotionChildDatabaseBlock.ps1
+++ b/source/Public/Block/Cmds/ChildDatabase/New-NotionChildDatabaseBlock.ps1
@@ -1,0 +1,38 @@
+function New-NotionChildDatabaseBlock
+{
+    <#
+    .SYNOPSIS
+        Creates a new Notion child database block object.
+
+    .DESCRIPTION
+        This function creates a new instance of the notion_child_database_block class.
+        You can create an empty child database block or provide a title for the database.
+
+    .PARAMETER Title
+        The title of the child database.
+
+    .EXAMPLE
+        New-NotionChildDatabaseBlock -Title "My Database"
+
+    .EXAMPLE
+        New-NotionChildDatabaseBlock
+
+    .OUTPUTS
+        notion_child_database_block
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
+    param (
+        [Parameter(ParameterSetName = 'Default')]
+        [string] $Title
+    )
+
+    if ($PSBoundParameters.ContainsKey('Title'))
+    {
+        $obj = [notion_child_database_block]::new($Title)
+    }
+    else
+    {
+        $obj = [notion_child_database_block]::new()
+    }
+    return $obj
+}

--- a/source/Public/Block/Cmds/ChildPage/New-NotionChildPageBlock.ps1
+++ b/source/Public/Block/Cmds/ChildPage/New-NotionChildPageBlock.ps1
@@ -23,7 +23,7 @@ function New-NotionChildPageBlock
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     [OutputType([notion_child_page_block])]
     param (
-        [Parameter(ParameterSetName = 'Default')]
+        [Parameter(ParameterSetName = 'Default', HelpMessage = 'Title of the child page.')]
         [string]$Title
     )
     $obj = $null

--- a/source/Public/Block/Cmds/ChildPage/New-NotionChildPageBlock.ps1
+++ b/source/Public/Block/Cmds/ChildPage/New-NotionChildPageBlock.ps1
@@ -1,0 +1,39 @@
+function New-NotionChildPageBlock
+{
+    <#
+    .SYNOPSIS
+        Creates a new Notion child page block object.
+
+    .DESCRIPTION
+        This function creates a new instance of the notion_child_page_block class.
+        You can create an empty child page block or provide a title for the page.
+
+    .PARAMETER Title
+        The title of the child page.
+
+    .EXAMPLE
+        New-NotionChildPageBlock -Title "My Page"
+
+    .EXAMPLE
+        New-NotionChildPageBlock
+
+    .OUTPUTS
+        notion_child_page_block
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
+    [OutputType([notion_child_page_block])]
+    param (
+        [Parameter(ParameterSetName = 'Default')]
+        [string]$Title
+    )
+    $obj = $null
+    if ($PSBoundParameters.ContainsKey('Title'))
+    {
+        $obj = [notion_child_page_block]::new($Title)
+    }
+    else
+    {
+        $obj = [notion_child_page_block]::new()
+    }
+    return $obj
+}

--- a/source/Public/Block/Cmds/Code/New-NotionCodeBlock.ps1
+++ b/source/Public/Block/Cmds/Code/New-NotionCodeBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionCodeBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/Code/New-NotionCodeBlock.ps1
+++ b/source/Public/Block/Cmds/Code/New-NotionCodeBlock.ps1
@@ -1,11 +1,61 @@
-function New-NotionCodeBlock {
-[CmdletBinding()]
-    [OutputType([void])]
-    param(
-        [Parameter(Mandatory = $True)]
-        $parameter1
-    )
-    
-throw [System.NotImplementedException]::new("This function is not yet implemented.")
+function New-NotionCodeBlock
+{
+    <#
+    .SYNOPSIS
+        Creates a new Notion code block object.
 
+    .DESCRIPTION
+        This function creates a new instance of the notion_code_block class.
+        You can create an empty code block, provide code text and language, or provide code text, caption, and language.
+
+    .PARAMETER Text
+        The code text to be included in the code block.
+
+    .PARAMETER Caption
+        The caption (rich_text[] or object) to be displayed above the code block.
+
+    .PARAMETER Language
+        The programming language for syntax highlighting in the code block.
+
+    .EXAMPLE
+        New-NotionCodeBlock -Text '$a = 1' -Language 'powershell'
+
+    .EXAMPLE
+        New-NotionCodeBlock -Text '$a = 1' -Caption 'Example' -Language 'powershell'
+
+    .EXAMPLE
+        New-NotionCodeBlock
+
+    .OUTPUTS
+        notion_code_block
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
+    param (
+        [Parameter(ParameterSetName = 'Default', HelpMessage = 'Code text for the code block.')]
+        $Text,
+
+        [Parameter(ParameterSetName = 'Default', HelpMessage = 'Caption to be displayed above the code block.')]
+        $Caption,
+
+        [Parameter(ParameterSetName = 'Default', HelpMessage = 'Programming language for syntax highlighting in the code block.')]
+        $Language
+    )
+
+    $Text = [rich_text]::ConvertFromObject($Text)
+    $Caption = [rich_text]::ConvertFromObject($Caption)
+    $Language = [code_structure]::ConvertFromObject($Language)
+
+    if ($PSBoundParameters.ContainsKey('Text') -and $PSBoundParameters.ContainsKey('Caption') -and $PSBoundParameters.ContainsKey('Language'))
+    {
+        $obj = [notion_code_block]::new($Text, $Caption, $Language)
+    }
+    elseif ($PSBoundParameters.ContainsKey('Text') -and $PSBoundParameters.ContainsKey('Language'))
+    {
+        $obj = [notion_code_block]::new($Text, $Language)
+    }
+    else
+    {
+        $obj = [notion_code_block]::new()
+    }
+    return $obj
 }

--- a/source/Public/Block/Cmds/Column/New-NotionColumnBlock.ps1
+++ b/source/Public/Block/Cmds/Column/New-NotionColumnBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionColumnBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/Column/New-NotionColumnBlock.ps1
+++ b/source/Public/Block/Cmds/Column/New-NotionColumnBlock.ps1
@@ -1,11 +1,38 @@
-function New-NotionColumnBlock {
-[CmdletBinding()]
-    [OutputType([void])]
-    param(
-        [Parameter(Mandatory = $True)]
-        $parameter1
-    )
-    
-throw [System.NotImplementedException]::new("This function is not yet implemented.")
+function New-NotionColumnBlock
+{
+    <#
+    .SYNOPSIS
+        Creates a new Notion column block object.
 
+    .DESCRIPTION
+        This function creates a new instance of the notion_column_block class.
+        You can create an empty column block or provide child blocks for the column.
+
+    .PARAMETER Children
+        The child blocks to include in the column.
+
+    .EXAMPLE
+        New-NotionColumnBlock -Children $childBlocks
+
+    .EXAMPLE
+        New-NotionColumnBlock
+
+    .OUTPUTS
+        notion_column_block
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
+    param (
+        [Parameter(ParameterSetName = 'Default')]
+        [object[]]$Children
+    )
+
+    if ($PSBoundParameters.ContainsKey('Children'))
+    {
+        $obj = [notion_column_block]::new($Children)
+    }
+    else
+    {
+        $obj = [notion_column_block]::new()
+    }
+    return $obj
 }

--- a/source/Public/Block/Cmds/ColumnList/New-NotionColumnListBlock.ps1
+++ b/source/Public/Block/Cmds/ColumnList/New-NotionColumnListBlock.ps1
@@ -1,11 +1,38 @@
-function New-NotionColumnListBlock {
-[CmdletBinding()]
-    [OutputType([void])]
-    param(
-        [Parameter(Mandatory = $True)]
-        $parameter1
-    )
-    
-throw [System.NotImplementedException]::new("This function is not yet implemented.")
+function New-NotionColumnListBlock
+{
+    <#
+    .SYNOPSIS
+        Creates a new Notion column list block object.
 
+    .DESCRIPTION
+        This function creates a new instance of the notion_column_list_block class.
+        You can create an empty column list block or provide child blocks for the column list.
+
+    .PARAMETER Children
+        The child blocks to include in the column list.
+
+    .EXAMPLE
+        New-NotionColumnListBlock -Children $childBlocks
+
+    .EXAMPLE
+        New-NotionColumnListBlock
+
+    .OUTPUTS
+        notion_column_list_block
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
+    param (
+        [Parameter(ParameterSetName = 'Default')]
+        [object[]]$Children
+    )
+
+    if ($PSBoundParameters.ContainsKey('Children'))
+    {
+        $obj = [notion_column_list_block]::new($Children)
+    }
+    else
+    {
+        $obj = [notion_column_list_block]::new()
+    }
+    return $obj
 }

--- a/source/Public/Block/Cmds/ColumnList/New-NotionColumnListBlock.ps1
+++ b/source/Public/Block/Cmds/ColumnList/New-NotionColumnListBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionColumnListBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/Divider/New-NotionDividerBlock.ps1
+++ b/source/Public/Block/Cmds/Divider/New-NotionDividerBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionDividerBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/Embed/New-NotionEmbedBlock.ps1
+++ b/source/Public/Block/Cmds/Embed/New-NotionEmbedBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionEmbedBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/Equation/New-NotionEquationBlock.ps1
+++ b/source/Public/Block/Cmds/Equation/New-NotionEquationBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionEquationBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/File/New-NotionFileBlock.ps1
+++ b/source/Public/Block/Cmds/File/New-NotionFileBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionFileBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/Image/New-NotionImageBlock.ps1
+++ b/source/Public/Block/Cmds/Image/New-NotionImageBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionImageBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/LinkPreview/New-NotionLinkPreviewBlock.ps1
+++ b/source/Public/Block/Cmds/LinkPreview/New-NotionLinkPreviewBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionLinkPreviewBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/NumberedListItem/New-NotionNumberedListItemBlock.ps1
+++ b/source/Public/Block/Cmds/NumberedListItem/New-NotionNumberedListItemBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionNumberedListItemBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/Paragraph/New-NotionParagraphBlock.ps1
+++ b/source/Public/Block/Cmds/Paragraph/New-NotionParagraphBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionParagraphBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/Pdf/New-NotionPdfBlock.ps1
+++ b/source/Public/Block/Cmds/Pdf/New-NotionPdfBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionPdfBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/Quote/New-NotionQuoteBlock.ps1
+++ b/source/Public/Block/Cmds/Quote/New-NotionQuoteBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionQuoteBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/Synced/New-NotionSyncedBlock.ps1
+++ b/source/Public/Block/Cmds/Synced/New-NotionSyncedBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionSyncedBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/Table/New-NotionTableBlock.ps1
+++ b/source/Public/Block/Cmds/Table/New-NotionTableBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionTableBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/TableOfContents/New-NotionTableOfContentsBlock.ps1
+++ b/source/Public/Block/Cmds/TableOfContents/New-NotionTableOfContentsBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionTableOfContentsBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/TableRow/New-NotionTableRowBlock.ps1
+++ b/source/Public/Block/Cmds/TableRow/New-NotionTableRowBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionTableRowBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/ToDo/New-NotionToDoBlock.ps1
+++ b/source/Public/Block/Cmds/ToDo/New-NotionToDoBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionToDoBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/Toggle/New-NotionToggleBlock.ps1
+++ b/source/Public/Block/Cmds/Toggle/New-NotionToggleBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionToggleBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/Cmds/Video/New-NotionVideoBlock.ps1
+++ b/source/Public/Block/Cmds/Video/New-NotionVideoBlock.ps1
@@ -1,0 +1,11 @@
+function New-NotionVideoBlock {
+[CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $True)]
+        $parameter1
+    )
+    
+throw [System.NotImplementedException]::new("This function is not yet implemented.")
+
+}

--- a/source/Public/Block/New-NotionBlock.ps1
+++ b/source/Public/Block/New-NotionBlock.ps1
@@ -1,0 +1,262 @@
+function New-NotionBlock
+{
+    [CmdletBinding(DefaultParameterSetName = 'paragraph')]
+    param (
+        [Parameter(ParameterSetName = 'bookmark', Mandatory = $true)]
+        [switch]$bookmark,
+        [Parameter(ParameterSetName = 'bookmark', Mandatory = $true)]
+        [string]$Url,        
+        [Parameter(ParameterSetName = 'bookmark')]
+        [object]$Caption,
+
+        [Parameter(ParameterSetName = 'breadcrumb', Mandatory = $true)]
+        [switch]$breadcrumb,
+
+        [Parameter(ParameterSetName = 'bulleted_list_item', Mandatory = $true)]
+        [switch]$bulleted_list_item,
+        [Parameter(ParameterSetName = 'bulleted_list_item', Mandatory = $true)]
+        $Text,
+        [Parameter(ParameterSetName = 'bulleted_list_item')]
+        [notion_color]$Color,
+
+        [Parameter(ParameterSetName = 'callout', Mandatory = $true)]
+        [switch]$callout,
+        [Parameter(ParameterSetName = 'callout')]
+        [switch]$Icon,
+
+        [Parameter(ParameterSetName = 'child_database', Mandatory = $true)]
+        [switch]$child_database,
+
+        [Parameter(ParameterSetName = 'child_page', Mandatory = $true)]
+        [switch]$child_page,
+
+        [Parameter(ParameterSetName = 'code', Mandatory = $true)]
+        [switch]$code,
+        [Parameter(ParameterSetName = 'code')]
+        [switch]$Language,
+
+        [Parameter(ParameterSetName = 'column', Mandatory = $true)]
+        [switch]$column,
+
+        [Parameter(ParameterSetName = 'column_list', Mandatory = $true)]
+        [switch]$column_list,
+
+        [Parameter(ParameterSetName = 'divider', Mandatory = $true)]
+        [switch]$divider,
+
+        [Parameter(ParameterSetName = 'embed', Mandatory = $true)]
+        [switch]$embed,
+
+        [Parameter(ParameterSetName = 'equation', Mandatory = $true)]
+        [switch]$equation,
+
+        [Parameter(ParameterSetName = 'file', Mandatory = $true)]
+        [switch]$file,
+
+        [Parameter(ParameterSetName = 'heading_1', Mandatory = $true)]
+        [switch]$heading_1,
+
+        [Parameter(ParameterSetName = 'heading_2', Mandatory = $true)]
+        [switch]$heading_2,
+
+        [Parameter(ParameterSetName = 'heading_3', Mandatory = $true)]
+        [switch]$heading_3,
+
+        [Parameter(ParameterSetName = 'image', Mandatory = $true)]
+        [switch]$image,
+
+        [Parameter(ParameterSetName = 'link_preview', Mandatory = $true)]
+        [switch]$link_preview,
+
+        [Parameter(ParameterSetName = 'link_to_page', Mandatory = $true)]
+        [switch]$link_to_page,
+
+        [Parameter(ParameterSetName = 'numbered_list_item', Mandatory = $true)]
+        [switch]$numbered_list_item,
+
+        [Parameter(ParameterSetName = 'paragraph', Mandatory = $true)]
+        [switch]$paragraph,
+
+        [Parameter(ParameterSetName = 'pdf', Mandatory = $true)]
+        [switch]$pdf,
+
+        [Parameter(ParameterSetName = 'quote', Mandatory = $true)]
+        [switch]$quote,
+
+        [Parameter(ParameterSetName = 'synced_block', Mandatory = $true)]
+        [switch]$synced_block,
+
+        [Parameter(ParameterSetName = 'table', Mandatory = $true)]
+        [switch]$table,
+
+        [Parameter(ParameterSetName = 'table_of_contents', Mandatory = $true)]
+        [switch]$table_of_contents,
+
+        [Parameter(ParameterSetName = 'table_row', Mandatory = $true)]
+        [switch]$table_row,
+
+        [Parameter(ParameterSetName = 'template', Mandatory = $true)]
+        [switch]$template,
+
+        [Parameter(ParameterSetName = 'to_do', Mandatory = $true)]
+        [switch]$to_do,
+        [Parameter(ParameterSetName = 'to_do')]
+        [switch]$Checked = $false,
+
+        [Parameter(ParameterSetName = 'toggle', Mandatory = $true)]
+        [switch]$toggle,
+
+        [Parameter(ParameterSetName = 'unsupported', Mandatory = $true)]
+        [switch]$unsupported,
+
+        [Parameter(ParameterSetName = 'video', Mandatory = $true)]
+        [switch]$video
+    )
+
+    # Beispielhafte Ausgabe
+    Write-Output "BlockType: $($PSCmdlet.ParameterSetName)"
+    Write-Output "Parameters: $($PSBoundParameters | Out-String)"
+    Write-Output "----"
+
+    switch ($PSCmdlet.ParameterSetName)
+    {
+        "bookmark"
+        { 
+            # Variant A
+            $block = ($caption) ? [notion_bookmark_block]::new($Url, $Caption) : [notion_bookmark_block]::new($Url)
+            # Variant B
+            Write-Host "[notion_bookmark_block]::new($Url)"
+            Write-Host "[notion_bookmark_block]::new($Url, $Caption)"
+
+        }
+        "breadcrumb"
+        {
+            $block = [notion_breadcrumb_block]::new() 
+        }
+        "bulleted_list_item"
+        {
+            $block = [notion_bulleted_list_item_block]::new() 
+        }
+        "callout"
+        {
+            $block = [notion_callout_block]::new() 
+        }
+        "child_database"
+        {
+            $block = [notion_child_database_block]::new() 
+        }
+        "child_page"
+        {
+            $block = [notion_child_page_block]::new() 
+        }
+        "code"
+        {
+            $block = [notion_code_block]::new() 
+        }
+        "column"
+        {
+            $block = [notion_column_block]::new() 
+        }
+        "column_list"
+        {
+            $block = [notion_column_list_block]::new() 
+        }
+        "divider"
+        {
+            $block = [notion_divider_block]::new() 
+        }
+        "embed"
+        {
+            $block = [notion_embed_block]::new() 
+        }
+        "equation"
+        {
+            $block = [notion_equation_block]::new() 
+        }
+        "file"
+        {
+            $block = [notion_file_block]::new() 
+        }
+        "heading_1"
+        {
+            $block = [notion_heading_1_block]::new() 
+        }
+        "heading_2"
+        {
+            $block = [notion_heading_2_block]::new() 
+        }
+        "heading_3"
+        {
+            $block = [notion_heading_3_block]::new() 
+        }
+        "image"
+        {
+            $block = [notion_image_block]::new() 
+        }
+        "link_preview"
+        {
+            $block = [notion_link_preview_block]::new() 
+        }
+        "link_to_page"
+        {
+            $block = [notion_link_to_page_block]::new() 
+        }
+        "numbered_list_item"
+        {
+            $block = [notion_numbered_list_item_block]::new() 
+        }
+        "paragraph"
+        {
+            $block = [notion_paragraph_block]::new() 
+        }
+        "pdf"
+        {
+            $block = [notion_pdf_block]::new() 
+        }
+        "quote"
+        {
+            $block = [notion_quote_block]::new() 
+        }
+        "synced_block"
+        {
+            $block = [notion_synced_block]::new() 
+        }
+        "table"
+        {
+            $block = [notion_table_block]::new() 
+        }
+        "table_of_contents"
+        {
+            $block = [notion_table_of_contents_block]::new() 
+        }
+        "table_row"
+        {
+            $block = [notion_table_row_block]::new() 
+        }
+        "template"
+        {
+            $block = [notion_template_block]::new() 
+        }
+        "to_do"
+        {
+            $block = [notion_to_do_block]::new() 
+        }
+        "toggle"
+        {
+            $block = [notion_toggle_block]::new() 
+        }
+        "unsupported"
+        {
+            $block = [notion_unsupported_block]::new() 
+        }
+        "video"
+        {
+            $block = [notion_video_block]::new() 
+        }
+        default
+        {
+            throw "Unbekannter Blocktyp: $($PSCmdlet.ParameterSetName)" 
+        }
+    }
+    return $block
+}

--- a/tests/Unit/Classes/Block/21_Link_Preview.tests.ps1
+++ b/tests/Unit/Classes/Block/21_Link_Preview.tests.ps1
@@ -1,1 +1,47 @@
+Import-Module Pester
 
+BeforeDiscovery {
+    $projectPath = "$($PSScriptRoot)/../../../.." | Convert-Path
+
+    if (-not $ProjectName)
+    {
+        $ProjectName = Get-SamplerProjectName -BuildRoot $projectPath
+    }
+    Write-Debug "ProjectName: $ProjectName"
+    $global:moduleName = $ProjectName
+
+    Remove-Module -Name $global:moduleName -Force -ErrorAction SilentlyContinue
+    $mut = Import-Module -Name "$projectPath/output/module/$ProjectName" -Force -ErrorAction Stop -PassThru
+}
+
+Describe "notion_link_preview_block Tests" {
+    Context "Constructor Tests" {
+        It "Should create an empty notion_link_preview_block" {
+            $block = [notion_link_preview_block]::new()
+            $block | Should -BeOfType "notion_link_preview_block"
+            $block.type | Should -Be "link_preview"
+            $block.link_preview | Should -BeNullOrEmpty
+        }
+
+        It "Should create a notion_link_preview_block with URL" {
+            $block = [notion_link_preview_block]::new("https://example.com")
+            $block.link_preview | Should -Not -BeNullOrEmpty
+            ($block.link_preview.GetType().Name) | Should -Be "link_preview_structure"
+            $block.link_preview.url | Should -Be "https://example.com"
+        }
+    }
+
+    Context "ConvertFromObject Tests" {
+        It "Should convert from object correctly" {
+            $mock = [PSCustomObject]@{
+                link_preview = [PSCustomObject]@{
+                    url = "https://notion.so"
+                }
+            }
+            $block = [notion_link_preview_block]::ConvertFromObject($mock)
+            $block | Should -BeOfType "notion_link_preview_block"
+            ($block.link_preview.GetType().Name) | Should -Be "link_preview_structure"
+            $block.link_preview.url | Should -Be "https://notion.so"
+        }
+    }
+}

--- a/tests/Unit/Classes/Block/22_Numbered_List_Item.tests.ps1
+++ b/tests/Unit/Classes/Block/22_Numbered_List_Item.tests.ps1
@@ -1,1 +1,69 @@
+Import-Module Pester
 
+BeforeDiscovery {
+    $projectPath = "$($PSScriptRoot)/../../../.." | Convert-Path
+
+    if (-not $ProjectName)
+    {
+        $ProjectName = Get-SamplerProjectName -BuildRoot $projectPath
+    }
+    Write-Debug "ProjectName: $ProjectName"
+    $global:moduleName = $ProjectName
+
+    Remove-Module -Name $global:moduleName -Force -ErrorAction SilentlyContinue
+    $mut = Import-Module -Name "$projectPath/output/module/$ProjectName" -Force -ErrorAction Stop -PassThru
+}
+
+Describe "notion_numbered_list_item_block Tests" {
+    Context "Constructor Tests" {
+        It "Should create an empty notion_numbered_list_item_block" {
+            $block = [notion_numbered_list_item_block]::new()
+            $block | Should -BeOfType "notion_numbered_list_item_block"
+            $block.type | Should -Be "numbered_list_item"
+            $block.numbered_list_item | Should -BeNullOrEmpty
+        }
+
+        It "Should create a notion_numbered_list_item_block with rich_text" {
+            $rt = [rich_text_text]::new("Item 1")
+            $block = [notion_numbered_list_item_block]::new(@($rt))
+            $block.numbered_list_item | Should -Not -BeNullOrEmpty
+            ($block.numbered_list_item.GetType().Name) | Should -Be "numbered_list_item_structure"
+            $block.numbered_list_item.rich_text[0].plain_text | Should -Be "Item 1"
+            $block.numbered_list_item.color.ToString() | Should -Be "default"
+        }
+    }
+
+    Context "ConvertFromObject Tests" {
+        It "Should convert from object correctly" {
+            $mock = [PSCustomObject]@{
+                numbered_list_item = [PSCustomObject]@{
+                    rich_text = @([PSCustomObject]@{
+                        type = "text"
+                        text = @{ content = "Converted item" }
+                        plain_text = "Converted item"
+                    })
+                    color = "red"
+                }
+            }
+            $block = [notion_numbered_list_item_block]::ConvertFromObject($mock)
+            $block | Should -BeOfType "notion_numbered_list_item_block"
+            ($block.numbered_list_item.GetType().Name) | Should -Be "numbered_list_item_structure"
+            $block.numbered_list_item.rich_text[0].plain_text | Should -Be "Converted item"
+            $block.numbered_list_item.color.ToString() | Should -Be "red"
+        }
+
+        It "Should default to 'default' color if none provided" {
+            $mock = [PSCustomObject]@{
+                numbered_list_item = [PSCustomObject]@{
+                    rich_text = @([PSCustomObject]@{
+                        type = "text"
+                        text = @{ content = "No color item" }
+                        plain_text = "No color item"
+                    })
+                }
+            }
+            $block = [notion_numbered_list_item_block]::ConvertFromObject($mock)
+            $block.numbered_list_item.color.ToString() | Should -Be "default"
+        }
+    }
+}

--- a/tests/Unit/Classes/Block/23_Paragraph.tests.ps1
+++ b/tests/Unit/Classes/Block/23_Paragraph.tests.ps1
@@ -1,1 +1,71 @@
+Import-Module Pester
 
+BeforeDiscovery {
+    $projectPath = "$($PSScriptRoot)/../../../.." | Convert-Path
+
+    if (-not $ProjectName)
+    {
+        $ProjectName = Get-SamplerProjectName -BuildRoot $projectPath
+    }
+    Write-Debug "ProjectName: $ProjectName"
+    $global:moduleName = $ProjectName
+
+    Remove-Module -Name $global:moduleName -Force -ErrorAction SilentlyContinue
+    $mut = Import-Module -Name "$projectPath/output/module/$ProjectName" -Force -ErrorAction Stop -PassThru
+}
+
+Describe "notion_paragraph_block Tests" {
+    Context "Constructor Tests" {
+        It "Should create an empty notion_paragraph_block" {
+            $block = [notion_paragraph_block]::new()
+            $block | Should -BeOfType "notion_paragraph_block"
+            $block.type | Should -Be "paragraph"
+            ($block.paragraph.GetType().Name) | Should -Be "paragraph_structure"
+            $block.paragraph.rich_text | Should -BeNullOrEmpty
+            "$($block.paragraph.color)" | Should -Be "default"
+            $block.paragraph.children | Should -BeNullOrEmpty
+        }
+
+        It "Should create a notion_paragraph_block with rich_text" {
+            $rt = [rich_text_text]::new("Hello world")
+            $block = [notion_paragraph_block]::new(@($rt))
+            $block.paragraph.rich_text.Count | Should -Be 1
+            $block.paragraph.rich_text[0].plain_text | Should -Be "Hello world"
+            $block.paragraph.color.ToString() | Should -Be "default"
+        }
+    }
+
+    Context "ConvertFromObject Tests" {
+        It "Should convert from object correctly" {
+            $mock = [PSCustomObject]@{
+                paragraph = [PSCustomObject]@{
+                    rich_text = @([PSCustomObject]@{
+                            type       = "text"
+                            text       = @{ content = "Converted text" }
+                            plain_text = "Converted text"
+                        })
+                    color     = "blue"
+                }
+            }
+            $block = [notion_paragraph_block]::ConvertFromObject($mock)
+            $block | Should -BeOfType "notion_paragraph_block"
+            ($block.paragraph.GetType().Name) | Should -Be "paragraph_structure"
+            $block.paragraph.rich_text[0].plain_text | Should -Be "Converted text"
+            $block.paragraph.color.ToString() | Should -Be "blue"
+        }
+
+        It "Should default to 'default' color if none provided" {
+            $mock = [PSCustomObject]@{
+                paragraph = [PSCustomObject]@{
+                    rich_text = @([PSCustomObject]@{
+                            type       = "text"
+                            text       = @{ content = "No color" }
+                            plain_text = "No color"
+                        })
+                }
+            }
+            $block = [notion_paragraph_block]::ConvertFromObject($mock)
+            $block.paragraph.color.ToString() | Should -Be "default"
+        }
+    }
+}


### PR DESCRIPTION
## [Unreleased]

### Added

- `.vscode/settings.json`: added `terminal.integrated.bracketedPasteMode`, disabled minimap, and configured custom terminal profile
- `.vscode/profile.ps1`: PowerShell profile to auto-import the module during development
- `.vscode/vsicons-custom-icons/`: added custom icon support for Pester files
- `.build/Copy-WikiContent.ps1`: script to copy wiki content from source to destination, flattening structure
- `.build/New-WikiSidebarFromPs1.ps1`: script to generate `_Sidebar.md` from PowerShell and Markdown files
- `.build/README.md`: documentation for adding custom build tasks and workflows
- `build.yaml`: added `minibuild` task with steps for `Clean`, `Build_Module_ModuleBuilder`, and `Build_NestedModules_ModuleBuilder`
- `source/Classes/03_File/01_notion_file.ps1`:  
  - Added static `Create` method to instantiate child objects based on file type
- `source/Classes/Block/RichText/01_Rich_Text.ps1`:  
  - Added `ConvertFromObjects` method to convert arrays or single objects into `rich_text[]`
- `source/Classes/Block/04_Block.ps1`:  
  - Improved error messages for unsupported and unknown block types with GitHub issue link and quoted block type
- `source/Classes/Block/05_Bookmark.ps1`:  
  - Refactored constructors to support flexible input types and added `ConvertFromObject` method
- `source/Classes/Block/07_Bulleted_List_Item.ps1`:  
  - Refactored constructors to use `ConvertFromObjects` and support flexible input
- `source/Classes/Block/08_Callout.ps1`:  
  - Refactored constructors and added `ConvertFromObject` for emoji and rich text
- `source/Classes/Block/09_Child_Database.ps1`:  
  - Used `ConvertFromObject` for `child_database_structure`
- `source/Classes/Block/10_Child_Page.ps1`:  
  - Used `ConvertFromObject` for `child_page_structure`
- `source/Classes/Block/11_Code.ps1`:  
  - Refactored constructors to use `ConvertFromObjects` and support caption
- `source/Classes/Block/15_Embed.ps1`:  
  - Added support for `caption` and `ConvertFromObject` improvements
- `source/Classes/Block/16_Equation.ps1`:  
  - Renamed constructors to match class name
- `source/Classes/Block/21_Image.ps1`:  
  - Added support for `caption` and improved `ConvertFromObject`
- `source/Classes/Block/31_To_do.ps1`:  
  - Refactored constructor to remove base call
- `source/Classes/Block/33_Video.ps1`:  
  - Refactored constructors to use `Create` method and support caption
- `source/Classes/Emoji/01_emoji.ps1`:  
  - Added `ConvertFromObject` method to handle strings and emoji objects
- `tests/Integration/Block/testpage.tests.ps1`:  
  - Improved test logic for unsupported block types with specific error message checks
- `source/Public/Block/New-NotionBlock.ps1`: generic factory function to create Notion blocks
- `source/Public/Block/Cmds/*`: added many new `New-Notion*Block.ps1` cmdlets for block creation (e.g., `Bookmark`, `Callout`, `ChildPage`, `Code`, etc.)
- `docs/Enums/`: added Markdown documentation for all enums used in the module
- `source/WikiSource/`: added wiki source files including setup guide, FAQ, and integration images
- `tests/Unit/Classes/Block/`: added unit tests for many block classes (e.g., `Bookmark`, `Breadcrumb`, `Callout`, `Code`, `Image`, `Video`, etc.)

### Changed

- `RequiredModules.psd1`: switched to Pester Version 6
- `.vscode/analyzersettings.psd1`: relaxed some analyzer rules (e.g., allow `Write-Host`)
- `.github/ISSUE_TEMPLATE/`: updated templates to reflect support for commands, classes, and enums
- `README.md`: added badges, logo, and improved getting started section
- `build.ps1`: added tasks `Generate_Wiki_Sidebar_From_Ps1` and `Copy_Wiki_Content_Custom`
- Refactored multiple constructors across block classes to support more flexible input types and use `ConvertFromObjects` for consistency
- `source/Classes/Emoji/01_emoji.ps1`: improved emoji conversion logic
- `source/Enum/*`: added missing enum values and documentation links

### Fixed

- `source/Enum/01_notion_color.ps1`: added `default_background` as a color (missing in documentation but available in API)
- `source/Classes/Block/32_Toggle.ps1`: fixed class name and constructor
- `source/Classes/Block/33_Video.ps1`: fixed constructors and file instantiation logic
- `source/Classes/Block/05_Bookmark.ps1`:  
  - Fixed constructors  
  - `bookmark_structure`: fixed constructor with two parameters to fully support `rich_text`
- `source/Classes/Block/07_Bulleted_List_Item.ps1`:  
  - Fixed `rich_text` conversion in constructors
- `source/Classes/Block/08_Callout.ps1`:  
  - Fixed constructors and emoji handling
- `source/Classes/Emoji/01_emoji.ps1`:  
  - Fixed `ConvertFromObject` to handle strings and emoji objects
- `tests/Integration/Block/testpage.tests.ps1`: improved error handling and validation for unsupported block types
- `tests/Integration/PageProperties/testpage.tests.ps1`: added validation for page property types
